### PR TITLE
feat(gitDiff-file-filter): implement git diff file filter 

### DIFF
--- a/packages/deprecation-crawler/src/lib/utils.ts
+++ b/packages/deprecation-crawler/src/lib/utils.ts
@@ -19,7 +19,7 @@ import {
 import { prompt } from 'enquirer';
 import * as yargs from 'yargs';
 import { join } from 'path';
-import simpleGit from 'simple-git';
+import simpleGit, { DiffResultTextFile } from 'simple-git';
 import * as kleur from 'kleur';
 import * as path from 'path';
 
@@ -295,6 +295,18 @@ export async function getCurrentBranchOrTag() {
 
 export async function branchHasChanges(): Promise<boolean> {
   return await git.status(['-s']).then((r) => Boolean(r.files.length));
+}
+
+export async function getFilesWithInsertionWithin2Hashes(diffConfig: {
+  from: string;
+  to: string;
+}) {
+  const gitDiff = await git.diffSummary([
+    `${diffConfig.from}...${diffConfig.to}`,
+  ]);
+  return gitDiff.files
+    .filter((f) => !f.binary && (f as DiffResultTextFile).insertions > 0)
+    .map((f) => f.file);
 }
 
 export async function getRemoteUrl(): Promise<string> {


### PR DESCRIPTION
This function filters for files withing 2 git tags that have insertions of lines (possible deprecation added)

closes #99  