### PR TITLE
fix: history command with init

### DIFF
--- a/packages/deprecation-crawler/sandbox/deprecations/raw-deprecations.json
+++ b/packages/deprecation-crawler/sandbox/deprecations/raw-deprecations.json
@@ -12,7 +12,7 @@
         ],
         "version": "5.4.2",
         "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git",
-        "date": "2020-09-14T03:19:37+02:00",
+        "date": "2020-09-13T09:30:07+02:00",
         "ruid": "3998890672",
         "group": "all-lowercase"
     },
@@ -29,7 +29,7 @@
         ],
         "version": "5.4.2",
         "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git",
-        "date": "2020-09-14T03:19:37+02:00",
+        "date": "2020-09-13T09:30:07+02:00",
         "ruid": "2129363187",
         "group": "all-lowercase"
     },
@@ -46,7 +46,7 @@
         ],
         "version": "5.4.2",
         "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git",
-        "date": "2020-09-14T03:19:37+02:00",
+        "date": "2020-09-13T09:30:07+02:00",
         "ruid": "2585813938",
         "group": "all-lowercase"
     },
@@ -63,7 +63,7 @@
         ],
         "version": "5.4.2",
         "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git",
-        "date": "2020-09-14T03:19:37+02:00",
+        "date": "2020-09-13T09:30:07+02:00",
         "ruid": "3397214801",
         "group": "comment-style"
     },
@@ -80,7 +80,7 @@
         ],
         "version": "5.4.2",
         "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git",
-        "date": "2020-09-14T03:19:37+02:00",
+        "date": "2020-09-13T09:30:07+02:00",
         "ruid": "456802929",
         "group": "comment-style"
     },
@@ -97,7 +97,7 @@
         ],
         "version": "5.4.2",
         "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git",
-        "date": "2020-09-14T03:19:37+02:00",
+        "date": "2020-09-13T09:30:07+02:00",
         "ruid": "242198417",
         "group": "comment-style"
     },
@@ -114,7 +114,7 @@
         ],
         "version": "5.4.2",
         "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git",
-        "date": "2020-09-14T03:19:37+02:00",
+        "date": "2020-09-13T09:30:07+02:00",
         "ruid": "2601492017",
         "group": "comment-style"
     },
@@ -131,7 +131,7 @@
         ],
         "version": "5.4.2",
         "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git",
-        "date": "2020-09-14T03:19:37+02:00",
+        "date": "2020-09-13T09:30:07+02:00",
         "ruid": "2711487569",
         "group": "comment-style"
     },
@@ -148,7 +148,7 @@
         ],
         "version": "5.4.2",
         "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git",
-        "date": "2020-09-14T03:19:37+02:00",
+        "date": "2020-09-13T09:30:07+02:00",
         "ruid": "1734398741",
         "group": "catch-all"
     },
@@ -165,7 +165,7 @@
         ],
         "version": "5.4.2",
         "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git",
-        "date": "2020-09-14T03:19:37+02:00",
+        "date": "2020-09-13T09:30:07+02:00",
         "ruid": "3477709142",
         "group": "catch-all"
     },
@@ -182,7 +182,7 @@
         ],
         "version": "5.4.2",
         "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git",
-        "date": "2020-09-14T03:19:37+02:00",
+        "date": "2020-09-13T09:30:07+02:00",
         "ruid": "2417065367",
         "group": "catch-all"
     },
@@ -199,7 +199,7 @@
         ],
         "version": "5.4.2",
         "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git",
-        "date": "2020-09-14T03:19:37+02:00",
+        "date": "2020-09-13T09:30:07+02:00",
         "ruid": "3186155811",
         "group": "whitespace-normalisation"
     },
@@ -216,7 +216,7 @@
         ],
         "version": "5.4.2",
         "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git",
-        "date": "2020-09-14T03:19:37+02:00",
+        "date": "2020-09-13T09:30:07+02:00",
         "ruid": "677771456",
         "group": "whitespace-normalisation"
     },
@@ -233,7 +233,7 @@
         ],
         "version": "5.4.2",
         "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git",
-        "date": "2020-09-14T03:19:37+02:00",
+        "date": "2020-09-13T09:30:07+02:00",
         "ruid": "3130163297",
         "group": "whitespace-normalisation"
     }

--- a/packages/deprecation-crawler/src/lib/commands/history.command.ts
+++ b/packages/deprecation-crawler/src/lib/commands/history.command.ts
@@ -1,9 +1,10 @@
-import { setup } from '../processors/setup';
 import { CrawledRelease, Deprecation, GitTag } from '../models';
 import {
   getCurrentBranchOrTag,
   git,
+  readRepoConfig,
   run,
+  updateRepoConfig,
   writeRawDeprecations,
 } from '../utils';
 import { YargsCommandObject } from '../cli/model';
@@ -11,12 +12,9 @@ import { checkout } from '../tasks/checkout';
 import { crawl } from '../processors/crawl';
 import { addVersion } from '../tasks/add-version';
 import { prompt } from 'enquirer';
-import { existsSync } from 'fs';
-import { join } from 'path';
-import { RAW_DEPRECATION_PATH } from '../constants';
-import { logError } from '../log';
 import { getTagChoices } from '../tasks/ensure-git-tag';
 import { ensureCleanGit } from '../tasks/ensure-clean-git';
+import { ensureConfigDefaults } from '../tasks/ensure-config';
 
 export const historyCommand: YargsCommandObject = {
   command: 'history',
@@ -24,17 +22,10 @@ export const historyCommand: YargsCommandObject = {
   module: {
     handler: async (argv) => {
       if (argv.verbose) console.info(`run history as a yargs command`);
-      const config = await setup();
-
-      const rawDeprecationsPath = join(
-        config.outputDirectory,
-        `${RAW_DEPRECATION_PATH}`
-      );
-      if (existsSync(rawDeprecationsPath)) {
-        logError(
-          'The history command can only be run on a clean repository without existing deprecations'
-        );
-        return;
+      let config = readRepoConfig();
+      const isInitialized = Object.keys(config).length > 0;
+      if (!isInitialized) {
+        config = await ensureConfigDefaults(config);
       }
 
       const current = await getCurrentBranchOrTag();
@@ -75,6 +66,9 @@ export const historyCommand: YargsCommandObject = {
         ...new Map(deprecations.map((r) => [r.ruid, r])).values(),
       ];
       writeRawDeprecations(uniqueDeprecations, config);
+      if (!isInitialized) {
+        updateRepoConfig(config);
+      }
     },
   },
 };

--- a/packages/deprecation-crawler/src/lib/commands/history.command.ts
+++ b/packages/deprecation-crawler/src/lib/commands/history.command.ts
@@ -14,7 +14,7 @@ import { addVersion } from '../tasks/add-version';
 import { prompt } from 'enquirer';
 import { getTagChoices } from '../tasks/ensure-git-tag';
 import { ensureCleanGit } from '../tasks/ensure-clean-git';
-import { ensureConfigDefaults } from '../tasks/ensure-config';
+import * as cfgQuestions from '../tasks/ensure-config';
 
 export const historyCommand: YargsCommandObject = {
   command: 'history',
@@ -25,7 +25,18 @@ export const historyCommand: YargsCommandObject = {
       let config = readRepoConfig();
       const isInitialized = Object.keys(config).length > 0;
       if (!isInitialized) {
-        config = await ensureConfigDefaults(config);
+        config = await {
+          ...(await cfgQuestions
+            .ensureDeprecationUrl(config)
+            .then(cfgQuestions.ensureDeprecationComment)
+            .then(cfgQuestions.ensureGroups)
+            .then(cfgQuestions.ensureFormatter)
+            .then(cfgQuestions.ensureOutputDirectory)
+            .then(cfgQuestions.ensureIncludeGlob)
+            .then(cfgQuestions.ensureExcludeGlob)
+            // defaults should be last as it takes user settings
+            .then(cfgQuestions.ensureConfigDefaults)),
+        };
       }
 
       const current = await getCurrentBranchOrTag();

--- a/packages/deprecation-crawler/src/lib/tasks/ensure-config/ensure-config-defaults.ts
+++ b/packages/deprecation-crawler/src/lib/tasks/ensure-config/ensure-config-defaults.ts
@@ -1,5 +1,14 @@
 import { CrawlConfig } from '../../models';
-import { HEALTH_CHECK_GROUP_NAME, SEMVER_TOKEN, TAG_FORMAT_TEMPLATE, UNGROUPED_GROUP_NAME } from '../../constants';
+import {
+  DEFAULT_COMMENT_LINK_TEMPLATE,
+  DEFAULT_COMMIT_MESSAGE,
+  DEFAULT_DEPRECATION_MSG_TOKEN,
+  DEPRECATIONS_OUTPUT_DIRECTORY,
+  HEALTH_CHECK_GROUP_NAME,
+  SEMVER_TOKEN,
+  TAG_FORMAT_TEMPLATE,
+  UNGROUPED_GROUP_NAME,
+} from '../../constants';
 import { getSiblingPgkJson, SERVER_REGEX } from '../../utils';
 
 export async function ensureConfigDefaults(
@@ -7,18 +16,33 @@ export async function ensureConfigDefaults(
 ): Promise<CrawlConfig> {
   return await {
     tagFormat: getSuggestedTagFormat(),
+    commitMessage: DEFAULT_COMMIT_MESSAGE,
+    commentLinkFormat: DEFAULT_COMMENT_LINK_TEMPLATE,
+    groups: [
+      { key: UNGROUPED_GROUP_NAME, matchers: [] },
+      {
+        key: HEALTH_CHECK_GROUP_NAME,
+        matchers: ['\\/\\*\\* *\\' + userConfig.deprecationComment + ' *\\*/'],
+      },
+    ],
+    outputDirectory: DEPRECATIONS_OUTPUT_DIRECTORY,
+    deprecationComment: DEFAULT_DEPRECATION_MSG_TOKEN,
+    include: './**/*.ts',
+    exclude: './**/*.(spec|test|d).ts',
     // override defaults with user settings
-    ...userConfig
+    ...userConfig,
   };
 }
 
-export function getDefaultGroups(deprecationComment: string): { key: string, matchers: string[] }[] {
+export function getDefaultGroups(
+  deprecationComment: string
+): { key: string; matchers: string[] }[] {
   return [
     { key: UNGROUPED_GROUP_NAME, matchers: [] },
     {
       key: HEALTH_CHECK_GROUP_NAME,
-      matchers: ['\\/\\*\\* *\\' + deprecationComment + ' *\\*/']
-    }
+      matchers: ['\\/\\*\\* *\\' + deprecationComment + ' *\\*/'],
+    },
   ];
 }
 

--- a/packages/deprecation-crawler/src/lib/tasks/ensure-config/ensure-fotmatters.ts
+++ b/packages/deprecation-crawler/src/lib/tasks/ensure-config/ensure-fotmatters.ts
@@ -6,10 +6,8 @@ import { CrawlConfig } from '../../models';
 export async function ensureFormatter(
   config: CrawlConfig
 ): Promise<CrawlConfig> {
-  if (config.outputFormatters.length <= 0) {
-    throw new Error(`No formatter registered! ${EOL}
-    builtInFormatter: ${Object.keys(builtInFormatter).join(', ')}${EOL}
-    Add outputFormatters to ${CRAWLER_CONFIG_PATH}.`);
+  if ((config.outputFormatters || []).length <= 0) {
+    return { ...config, outputFormatters: Object.keys(builtInFormatter) };
   }
 
   const configuredAndExistingFormatter = Object.entries(builtInFormatter)

--- a/packages/deprecation-crawler/src/lib/tasks/ensure-config/ensure-groups.ts
+++ b/packages/deprecation-crawler/src/lib/tasks/ensure-config/ensure-groups.ts
@@ -2,18 +2,19 @@ import { CrawlConfig } from '../../models';
 import { getDefaultGroups } from './ensure-config-defaults';
 import { ensureDeprecationComment } from './ensure-deprecation-comment';
 
-export async function ensureGroups(
-  config: CrawlConfig
-): Promise<CrawlConfig> {
+export async function ensureGroups(config: CrawlConfig): Promise<CrawlConfig> {
   if (!config.deprecationComment) {
     config = {
       ...config,
-      ...await ensureDeprecationComment(config)
+      ...(await ensureDeprecationComment(config)),
     };
   }
 
   return await {
     ...config,
-    groups: config.groups.length <= 0 ? await getDefaultGroups(config.deprecationComment) : config.groups
+    groups:
+      (config.groups || []).length <= 0
+        ? await getDefaultGroups(config.deprecationComment)
+        : config.groups,
   };
 }


### PR DESCRIPTION
The current behavior of the history command expects that the config file exists.

This PR removes that prerequisite and uses the default config setting if no config file exists in the target repo.
After the history command it run, it will also save the config file to disk.